### PR TITLE
Make theme link to wiki larger

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a collection of themes for [spicetify](https://github.com/khanhas/spicetify-cli), a command-line tool to customize Spotify; you can add your own theme simply by opening a Pull Requests (more info in the Contributions section).
 
-You can find a preview of all the themes in the [wiki](https://github.com/morpheusthewhite/spicetify-themes/wiki/Themes-preview).
+### **You can find a preview of all the themes in the [wiki](https://github.com/morpheusthewhite/spicetify-themes/wiki/Themes-preview).**
 
 ## Installation
 


### PR DESCRIPTION
When I first viewed the README for this repo, I completely missed the preview of all themes on the wiki. I figured it might help to make the size of the line in the README that directs readers to the wiki to preview the themes a bit larger, which is what I did.