### PR TITLE
add Gruvbox color for Kaapi theme

### DIFF
--- a/Kaapi/color.ini
+++ b/Kaapi/color.ini
@@ -16,4 +16,22 @@ miscellaneous_bg                      = 292929
 miscellaneous_hover_bg                = 292929
 preserve_1                            = 4052b3
 
+[Gruvbox]
+main_fg                               = d79921
+secondary_fg                          = fbf1c7
+main_bg                               = 1d2021
+sidebar_and_player_bg                 = 282828
+cover_overlay_and_shadow              = 32302f
+indicator_fg_and_button_bg            = 98971a
+pressing_fg                           = b8bb26
+slider_bg                             = 32302f
+sidebar_indicator_and_hover_button_bg = 689d6a
+scrollbar_fg_and_selected_row_bg      = 1d2021
+pressing_button_fg                    = 928374
+pressing_button_bg                    = 8ec07c
+selected_button                       = b16286
+miscellaneous_bg                      = 32302f
+miscellaneous_hover_bg                = 282828
+preserve_1                            = ff0000
+
 


### PR DESCRIPTION
Hi @Jom97 , I took your work as a basis for applying the Gruvbox colour palette :
https://github.com/morhetz/gruvbox-contrib

But I couldn't find where the color of "preserve_1" is applied.

![gruvbox-spoty](https://user-images.githubusercontent.com/1497894/81452747-ecf03880-9187-11ea-9303-56bddd477247.png)
