### PR TITLE
Dribblish: README: Fix white color scheme references

### DIFF
--- a/Dribbblish/README.md
+++ b/Dribbblish/README.md
@@ -4,7 +4,7 @@
 #### Base
 ![demo1](./base.png)
 
-#### Gow
+#### White
 ![demo2](./white.png)
 
 #### Dark
@@ -40,7 +40,7 @@ spicetify apply
 Windows user, please edit your Spotify shortcut and add flag `--transparent-window-controls` after the Spotify.exe:  
 ![instruction1](./windows-shortcut-instruction.png)
 
-There are 3 color schemes you can choose: `base`, `light`, `dark`. Change scheme with commands:
+There are 3 color schemes you can choose: `base`, `white`, `dark`. Change scheme with commands:
 ```
 spicetify config color_scheme <scheme name>
 spicetify apply


### PR DESCRIPTION
The white color scheme is named "light" in one place and "gow" in another, and I had to open `color.ini` to find out the real color scheme name. This fixes it and will make for a better first-time experience.