### PR TITLE
Add an icon for JQBX

### DIFF
--- a/Dribbblish/dribbblish.js
+++ b/Dribbblish/dribbblish.js
@@ -84,6 +84,7 @@ waitForElement([".LeftSidebar", ".LeftSidebar__section--rootlist .SidebarList__l
         .forEach(item => {
             let icon = ((app) => {switch (app) {
                 case "genius":                  return "lyrics";
+                case "JQBX":                    return "addsuggestedsong";
                 case "bookmark":                return "tag";
                 case "reddit":                  return "discover";
                 case "made-for-you":            return "user";


### PR DESCRIPTION
This will add an icon for the custom app JQBX https://github.com/Kasama/spicetify-jqbx
With this pull request https://github.com/Kasama/spicetify-jqbx/pull/1 it should work.

It won't work yet, but after the above is committed, it should.