### PR TITLE
Update README.md

### DIFF
--- a/Dribbblish/README.md
+++ b/Dribbblish/README.md
@@ -32,7 +32,10 @@
 ![demo8](./purple.png)
 
 ## More
+Requires spicetify-cli **v0.9.9 or newer**.
+
 ### How to install
+
 Run these command:
 
 #### Linux and MacOS:


### PR DESCRIPTION
This themes uses custom color keys and this is support in v0.9.9 or newer.

Chocolatey, for example, still serves the v0.9.4, which why some colors are not declared at :root.