### PR TITLE
Improve Gruvbox-Gold

### DIFF
--- a/Gruvbox-Gold/color.ini
+++ b/Gruvbox-Gold/color.ini
@@ -16,3 +16,4 @@ selected_button                             = FABD2F
 miscellaneous_bg                            = 1D2021
 miscellaneous_hover_bg                      = 1D2021
 preserve_1                                  = EBDBB2
+indicator_fg_and_button_bg                  = A89984


### PR DESCRIPTION
This (hopefully) removes every last piece of default Spotify green from the Gruvbox-Gold on buttons and progress bars.