### PR TITLE
Add Sidebar Color Updates

### DIFF
--- a/DribbblishDynamic/dribbblish-dynamic.js
+++ b/DribbblishDynamic/dribbblish-dynamic.js
@@ -254,6 +254,14 @@ function updateColors(root) {
     //root.style.setProperty('--modspotify_rgb_scrollbar_fg_and_selected_row_bg', darkerColRGB)
     root.style.setProperty('--modspotify_rgb_selected_button', darkerColRGB)
     //root.style.setProperty('--modspotify_rgb_miscellaneous_hover_bg', colRGB)
+    // Also update the color of the icons for bright and white backgrounds to remain readable.
+    var colRGB = colRGB.split(",")
+    var brightness = Math.round(((parseInt(colRGB[0]) * 299) +
+        (parseInt(colRGB[1]) * 587) +
+        (parseInt(colRGB[2]) * 114)) / 1000);
+    var textColour = (brightness > 125) ? '#000000' : '#ffffff';
+    root.style.setProperty('--modspotify_preserve_1', textColour);
+    
 }
 
 function updateColorsAllIframes() {


### PR DESCRIPTION
This simple modification to the update js adds the ability for the icons in the left menu to update to a dark color when there is a bright background.

This fixes Issue #260

before: see issue.

after (on darker background):
![image](https://user-images.githubusercontent.com/23525377/107202217-3bbe4d80-69fa-11eb-9baa-3c8ed278eea4.png)


after (on bright background):
![image](https://user-images.githubusercontent.com/23525377/107202192-2fd28b80-69fa-11eb-8e81-dd06c482526f.png)
