### PR TITLE
[DribblishDynamic] Better display of the large album cover in the friends list

### DIFF
--- a/DribbblishDynamic/dribbblish-dynamic.js
+++ b/DribbblishDynamic/dribbblish-dynamic.js
@@ -178,6 +178,20 @@ waitForElement([".LeftSidebar"], (queries) => {
     queries[0].append(fade);
 });
 
+var big_album_cover = document.querySelector('#now-playing-image-small');
+
+var observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+        if (mutation.type == "attributes") {
+            if(big_album_cover.getAttribute("data-log-context") === "cover-large"){
+                document.documentElement.style.setProperty('--move_buddy_list', "250px");
+            }else{
+                document.documentElement.style.setProperty('--move_buddy_list', "0px");
+            }
+        }
+    });
+});
+
 function getAlbumInfo(uri) {
     return new Promise((resolve) => { Spicetify.CosmosAPI.resolver.get(`hm://album/v1/album-app/album/${uri}/desktop`, (err, raw) => {
         resolve(!err && raw.getJSONBody())

--- a/DribbblishDynamic/user.css
+++ b/DribbblishDynamic/user.css
@@ -11,6 +11,7 @@
     --os-windows-icon-dodge: 1;
     --image_url: '';
     --is_light: 0;
+    --move_buddy_list: 0px;
 }
 
 div#popover-container::before {
@@ -974,6 +975,11 @@ select {
 }
 
 /* Friend list */
+
+.body-container--windows .buddy-list-iframe {
+    margin-top: 48px;
+    margin-bottom: var(--move_buddy_list);
+}
 
 .buddy-list-title h3 {
     font-weight: 500;


### PR DESCRIPTION
The album cover is now no longer displayed over the friends list and is now inserted in the bar so that the friends list slides up. 
This makes it possible to scroll all the way down in the friends list even when displaying the large cover. 
An example can be seen below.
![Example](https://user-images.githubusercontent.com/32893711/109416796-a0007b80-79c0-11eb-9ceb-365b8ca5534d.PNG)
