### PR TITLE
[Onepunch] Theme is trying to load the Spotify logo from a local server

### DIFF
--- a/Onepunch/user.css
+++ b/Onepunch/user.css
@@ -77,7 +77,7 @@ html .SidebarList__title {
 }
 /* the spotify logo and layout fix */
 .sidebar .sidebar-navbar {
-  background-image     : url("https://local_resource_host/images/spotify-logo-green.png");
+  background-image     : url("https://i.imgur.com/pFLYMRv.png");
   background-repeat    : no-repeat;
   background-size      : 150px;
   background-position-x: 25px;


### PR DESCRIPTION
The original author of the theme specified a local server for the Spotify logo asset file, which logically caused the logo not to be displayed. I have linked to a public Imgur upload so you can see the logo again.