### PR TITLE
[#312] Updated color.ini so messages are visible

### DIFF
--- a/Arc-Dark/color.ini
+++ b/Arc-Dark/color.ini
@@ -14,7 +14,7 @@ pressing_button_fg                    = 5294E2
 pressing_button_bg                    = 303642
 selected_button                       = 5294E2
 miscellaneous_bg                      = 303642
-miscellaneous_hover_bg                = FFFFFF
+miscellaneous_hover_bg                = 414A59 ;handles the hovering for liked songs etc
 preserve_1                            = FFFFFF
 
 [Aritim-Dark]
@@ -33,6 +33,5 @@ pressing_button_fg                    = 516A86
 pressing_button_bg                    = 303642
 selected_button                       = 516A86
 miscellaneous_bg                      = 303642
-miscellaneous_hover_bg                = FFFFFF
+miscellaneous_hover_bg                = 141A21 ;handles the hovering for liked songs etc
 preserve_1                            = FFFFFF
-


### PR DESCRIPTION
The BG color used is used as a primary component of the theme, as to ensure it "fits the theme" so to speak