### PR TITLE
Fixes Dribbblish/Dracula active button indicators

### DIFF
--- a/Dribbblish/color.ini
+++ b/Dribbblish/color.ini
@@ -51,7 +51,7 @@ preserve_1                            = 0a0e14
 
 [dracula]
 main_fg                               = 6272A4
-active_control_fg                     = e9e9f4
+active_control_fg                     = 6272A4
 secondary_fg                          = DEDEDE
 secondary_bg                          = 1D1E27
 main_bg                               = 282936
@@ -64,7 +64,7 @@ sidebar_indicator_and_hover_button_bg = e9e9f4
 scrollbar_fg_and_selected_row_bg      = 4d4f68
 pressing_button_fg                    = e9e9f4
 pressing_button_bg                    = 3a3c4e
-selected_button                       = 00BF76
+selected_button                       = 50fa7b
 miscellaneous_bg                      = FF5555
 miscellaneous_hover_bg                = FF5555
 preserve_1                            = FFFFFF


### PR DESCRIPTION
Not sure how I missed this, but this fixes the active button indicator colors.