### PR TITLE
dribbblish: add border radius to `#view-now-playing`

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -1322,6 +1322,7 @@ button#player-button-repeat,
 #view-now-playing.expanded {
     bottom: calc(var(--bar-height) + var(--main-gap));
     left: var(--sidebar-width);
+    border-top-right-radius: var(--main-corner-radius);
 }
 
 #view-now-playing a.image.large figure,

--- a/DribbblishDynamic/user.css
+++ b/DribbblishDynamic/user.css
@@ -389,7 +389,7 @@ select {
     background-color: var(--modspotify_indicator_fg_and_button_bg);
     color: var(--modspotify_secondary_fg);
     padding: 10px 10px;
-    
+
     backface-visibility: hidden;
     transform: translateZ(0);
     backdrop-filter: blur(20px);
@@ -1411,6 +1411,7 @@ button#player-button-repeat,
 #view-now-playing.expanded {
     bottom: calc(2 * var(--main-gap) + var(--bar-height) + 2px);
     right:  calc(2 * var(--main-gap));
+    border-top-right-radius: var(--main-corner-radius);
 }
 
 #view-now-playing a.image.large figure,


### PR DESCRIPTION
Adds property `border-top-right-radius` to `#view-now-playing.expanded`, since it looked really weird without a border radius while everything else had rounded corners.

Before: 
![image](https://user-images.githubusercontent.com/55749227/118299816-3a943500-b4af-11eb-96c0-b22ae6cf3961.png)

After: 
![image](https://user-images.githubusercontent.com/55749227/118299827-3ff17f80-b4af-11eb-8717-9ef7d48f88dc.png)
