### PR TITLE
dribbblish: fix border radius for "new" cover position

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -1322,7 +1322,7 @@ button#player-button-repeat,
 #view-now-playing.expanded {
     bottom: calc(var(--bar-height) + var(--main-gap));
     left: var(--sidebar-width);
-    border-top-right-radius: var(--main-corner-radius);
+    border-radius: var(--cover-border-radius);
 }
 
 #view-now-playing a.image.large figure,

--- a/DribbblishDynamic/user.css
+++ b/DribbblishDynamic/user.css
@@ -1411,7 +1411,7 @@ button#player-button-repeat,
 #view-now-playing.expanded {
     bottom: calc(2 * var(--main-gap) + var(--bar-height) + 2px);
     right:  calc(2 * var(--main-gap));
-    border-top-right-radius: var(--main-corner-radius);
+    border-radius: var(--cover-border-radius);
 }
 
 #view-now-playing a.image.large figure,


### PR DESCRIPTION
I just realized that when I made #353, I was using a **really** old version of dribbblish (at least 7 months behind), and the cover image was still on the left. Since 7d174f3b2bcd81c9453d3678b6f2a338ba2049d2 moved it to the right, the single rounded border looks really weird.

This just adds a border radius all around the cover, or if you think that doesn't look good, you can just get rid of the border radius completely.

Before:
![image](https://user-images.githubusercontent.com/55749227/118501751-0e6af500-b6f7-11eb-9207-f54f1d08c114.png)

After:
![image](https://user-images.githubusercontent.com/55749227/118501789-1460d600-b6f7-11eb-8deb-014ba76f5511.png)
