### PR TITLE
feat(Dribblish): Gruvbox color scheme + QoF CSS Changes

### DIFF
--- a/Dribbblish/color.ini
+++ b/Dribbblish/color.ini
@@ -160,3 +160,21 @@ tab-active         = f1a84f
 notification       = c98430
 notification-error = e22134
 misc               = BFBFBF
+
+[gruvbox]
+text               = d5c4a1
+subtext            = d5c4a1
+sidebar-text       = 32302f
+main               = 292828
+sidebar            = 689d6a
+player             = 292828
+card               = 292828
+shadow             = 202020
+selected-row       = d5c4a1
+button             = 8ec07c
+button-active      = 8ec07c
+button-disabled    = 535353
+tab-active         = 8ec07c
+notification       = 8ec07c
+notification-error = e22134
+misc               = 83a598

--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -277,8 +277,8 @@ span.artist-artistVerifiedBadge-badge svg:nth-child(1) {
 
 .main-connectBar-connectBar {
     border-radius: 0 0 var(--main-corner-radius) var(--main-corner-radius);
-    border: 2px solid var(--spice-sidebar);
-    border-top: 0;
+    border: 2px solid var(--spice-main);
+    border-top: 2px solid var(--spice-sidebar);
     background-color: var(--spice-main);
     font-size: 10px;
 }

--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -113,7 +113,7 @@ input {
 .main-entityHeader-shadow,
 .main-contextMenu-menu,
 .connect-device-list-container {
-    box-shadow: 0 4px 20px #292828;
+    box-shadow: 0 4px 20px #21212130;
 }
 
 .main-trackList-playingIcon {
@@ -271,12 +271,14 @@ span.artist-artistVerifiedBadge-badge svg:nth-child(1) {
     border-radius: 0 0 var(--main-corner-radius) var(--main-corner-radius);
     border-top: 0;
     min-width: 518px;
+    background-color: unset;
+    background: radial-gradient(ellipse at right 50% bottom -80px, rgba(var(--spice-rgb-button), 0.55), var(--spice-main) 60%);
 }
 
 .main-connectBar-connectBar {
     border-radius: 0 0 var(--main-corner-radius) var(--main-corner-radius);
     border: 2px solid var(--spice-sidebar);
-    border-bottom: 0;
+    border-top: 0;
     background-color: var(--spice-main);
     font-size: 10px;
 }

--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -50,6 +50,7 @@ body {
 .main-type-canon {
     font-family: var(--info-font-family);
     letter-spacing: normal;
+    
 }
 
 .main-type-ballad {
@@ -112,7 +113,7 @@ input {
 .main-entityHeader-shadow,
 .main-contextMenu-menu,
 .connect-device-list-container {
-    box-shadow: 0 4px 20px #21212130;
+    box-shadow: 0 4px 20px #292828;
 }
 
 .main-trackList-playingIcon {
@@ -268,16 +269,16 @@ span.artist-artistVerifiedBadge-badge svg:nth-child(1) {
 
 .main-nowPlayingBar-container {
     border-radius: 0 0 var(--main-corner-radius) var(--main-corner-radius);
-    background-color: unset;
-    background: radial-gradient(ellipse at right 50% bottom -80px, rgba(var(--spice-rgb-button), 0.55), var(--spice-main) 60%);
     border-top: 0;
     min-width: 518px;
 }
 
 .main-connectBar-connectBar {
     border-radius: 0 0 var(--main-corner-radius) var(--main-corner-radius);
-    border: 2px solid var(--spice-main);
-    border-top: 0;
+    border: 2px solid var(--spice-sidebar);
+    border-bottom: 0;
+    background-color: var(--spice-main);
+    font-size: 10px;
 }
 
 @media(max-width:768px){


### PR DESCRIPTION
- Added a Gruvbox color scheme (adapted from the legacy theme)
- Changed the connect bar's background color to match the player while giving it a top border with the sidebar's color to improve clarity (also changed the font size to 10px to improve looks)

(Extremely sorry if I made any beginner mistakes, as I'm just getting into CSS and Github collaboration)