### PR TITLE
fix(Dribbblish) Fixed bug preventing Dribbblish's context menu from working.

### DIFF
--- a/Dribbblish/dribbblish.js
+++ b/Dribbblish/dribbblish.js
@@ -13,7 +13,7 @@ const DribbblishShared = {
 };
 
 DribbblishShared.configMenu.register();
-DribbblishShared.configMenu.addItem(new Spicetify.Menu.Item(
+DribbblishShared.configMenu.subItems.push(new Spicetify.Menu.Item(
     "Right expanded cover",
     DribbblishShared.rightBigCover,
     (self) => {


### PR DESCRIPTION
"DribbblishShared.configMenu.addItems" is not a valid function, replaced to "DribbblishShared.configMenu.subItems.push" to allow for the theme to work properly again.