### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,41 +16,40 @@ You can add your own theme simply by opening a Pull Request (more info in the [C
 (If you use Arch Linux you can find this project on the [AUR](https://aur.archlinux.org/packages/spicetify-themes-git/))
 
 1. Clone this repository. Make sure [git](https://git-scm.com/) is installed and run:
-
-```bash
-git clone https://github.com/morpheusthewhite/spicetify-themes.git
-```
+    ```bash
+    git clone https://github.com/morpheusthewhite/spicetify-themes.git
+    ```
 
 2. Copy the files into the [Spicetify Themes folder](https://github.com/khanhas/spicetify-cli/wiki/Customization#themes). Run:
+    
+    **Linux**
+    ```bash
+    cd spicetify-themes
+    cp -r * ~/.config/spicetify/Themes
+    ```
 
-**Linux**
-```bash
-cd spicetify-themes
-cp -r * ~/.config/spicetify/Themes
-```
+    **MacOS**
 
-**MacOS**
+    ```bash
+    cd spicetify-themes
+    cp -r * ~/spicetify_data/Themes
+    ```
 
-```bash
-cd spicetify-themes
-cp -r * ~/spicetify_data/Themes
-```
+    **Windows** 
 
-**Windows** 
+    ```powershell
+    cd spicetify-themes
+    cp * "$(spicetify -c | Split-Path)\Themes\"
+    ```
 
-```powershell
-cd spicetify-themes
-cp * "$(spicetify -c | Split-Path)\Themes\"
-```
-  
 3. Choose which theme to apply just by running: 
-```bash
-spicetify config current_theme THEME_NAME. 
-```
-Some themes have 2 or more different color schemes. After selecting the theme you can switch between them with:
-```bash
-spicetify config color_scheme SCHEME_NAME
-```
+    ```bash
+    spicetify config current_theme THEME_NAME
+    ```
+    Some themes have 2 or more different color schemes. After selecting the theme you can switch between them with:
+    ```bash
+    spicetify config color_scheme SCHEME_NAME
+    ```
 
 ## Contributions
 
@@ -59,19 +58,19 @@ If you want to add your theme:
 - Fork this repository
 - Create another folder with your theme name. The theme name should consist of one word starting with an uppercase letter and shouldn't contain `spicetify` or any whitespace in it; if a "-" is present in the name it must be followed by an uppercase letter.
 - Copy `color.ini` and `user.css` into it
-- Create a `README.md` in it with the following structure 
-```markdown
-# THEME_NAME
+- Create a `README.md` in it with the following structure:
+    ```markdown
+    # THEME_NAME
 
-## Screenshots
+    ## Screenshots
 
-[Put at least one image per color scheme here]
+    [Put at least one image per color scheme here]
 
-## More
+    ## More
 
-[Specify any needed font; (optionally) author name and/or any other info about the theme]
+    [Specify any needed font; (optionally) author name and/or any other info about the theme]
 
-```
+    ```
 - Open a Pull Request
 
 **Thanks to all contributors.**

--- a/README.md
+++ b/README.md
@@ -1,26 +1,57 @@
 # spicetify community themes
 
-This is a collection of themes for [spicetify](https://github.com/khanhas/spicetify-cli), a command-line tool to customize Spotify; you can add your own theme simply by opening a Pull Requests (more info in the Contributions section).
+This is a collection of themes for [spicetify](https://github.com/khanhas/spicetify-cli), a command-line tool to customize Spotify. 
+
+You can add your own theme simply by opening a Pull Request (more info in the [Contributions section](#contributions)).
 
 ### **You can find a preview of all the themes in the [wiki](https://github.com/morpheusthewhite/spicetify-themes/wiki/Themes-preview).**
 
-**Note that these themes require you to have the old Spotify UI (<v1.1.56) and Spicetify <v2**
+## Notes:
+- **These themes require you to have the old Spotify UI (<v1.1.56) and [Spicetify <v2](https://github.com/khanhas/spicetify-cli/wiki/Installation#legacy-spotify)**
+- **To install Dribbblish and DribbblishDynamic, follow the instructions in their READMEs**.  
+- **Spotify ad-blocked version is not supported.**
 
 ## Installation and usage
 
 (If you use Arch Linux you can find this project on the [AUR](https://aur.archlinux.org/packages/spicetify-themes-git/))
 
-Once you cloned the repository you'll need to put the files into the Themes folder. This varies between operating systems. The example shows the `Themes` directory for Linux. For other operating systems, see the `Themes` folder location [here](https://github.com/khanhas/spicetify-cli/wiki/Customization#themes).
+### Clone this repository. Make sure [git](https://git-scm.com/) is installed and run:
 
+```bash
+git clone https://github.com/morpheusthewhite/spicetify-themes.git
+```
+
+### Copy the files into the [Spicetify Themes folder](https://github.com/khanhas/spicetify-cli/wiki/Customization#themes). Run:
+
+**Windows** 
+
+```powershell
+cd spicetify-themes
+cp * "$(spicetify -c | Split-Path)\Themes\"
+```
+
+**MacOS**
+
+```bash
+cd spicetify-themes
+cp -r * ~/spicetify_data/Themes
+```
+
+**Linux**
 ```bash
 cd spicetify-themes
 cp -r * ~/.config/spicetify/Themes
 ```
+
   
-**NOTE: to install Dribbblish and DribbblishDynamic follow the instructions in its README**.  
-  
-After that you can choose which theme to apply just by running `spicetify config current_theme THEME_NAME`. 
-Some themes have 2 or more different color schemes. You can switch between them, once selected the theme, with `spicetify config color_scheme SCHEME_NAME`.
+### Choose which theme to apply just by running: 
+```bash
+spicetify config current_theme THEME_NAME. 
+```
+#### Some themes have 2 or more different color schemes. After selecting the theme you can switch between them with:
+```bash
+spicetify config color_scheme SCHEME_NAME
+```
 
 ## Contributions
 
@@ -44,15 +75,13 @@ If you want to add your theme:
 ```
 - Open a Pull Request
 
-**Thanks to all the contributors.**
+**Thanks to all contributors.**
 
 ## Troubleshooting
 
-If you find problems when using or installing these themes, or you need help in modifying a theme 
+- If you find problems when using or installing these themes, or you need help in modifying a theme, 
 use the [Spectrum](https://spectrum.chat/spicetify) chat. 
 
-For bugs and requesting new features use the GitHub issues. 
+- For bugs and requesting new features, [open an issue](https://github.com/morpheusthewhite/spicetify-themes/issues/new/choose) on GitHub
 
-If you are unsure about which channel to use, go for Spectrum.
-
-NOTE: Spotify ad-blocked version is not supported.
+If you are unsure about which one to use, go for Spectrum.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ You can add your own theme simply by opening a Pull Request (more info in the [C
 ### **You can find a preview of all the themes in the [wiki](https://github.com/morpheusthewhite/spicetify-themes/wiki/Themes-preview).**
 
 ## Notes:
-- **These themes require you to have the old Spotify UI (<v1.1.56) and [Spicetify <v2](https://github.com/khanhas/spicetify-cli/wiki/Installation#legacy-spotify)**
+- **These themes require you to have the old Spotify UI (<v1.1.56) and [Spicetify <v2](https://github.com/khanhas/spicetify-cli/wiki/Installation#legacy-spotify).**
 - **To install Dribbblish and DribbblishDynamic, follow the instructions in their READMEs**.  
 - **Spotify ad-blocked version is not supported.**
 
 ## Installation and usage
 
-(If you use Arch Linux you can find this project on the [AUR](https://aur.archlinux.org/packages/spicetify-themes-git/))
+(If you use Arch Linux you can find this project on the [AUR](https://aur.archlinux.org/packages/spicetify-themes-git/)).
 
 ### Clone this repository. Make sure [git](https://git-scm.com/) is installed and run:
 
@@ -82,6 +82,6 @@ If you want to add your theme:
 - If you find problems when using or installing these themes, or you need help in modifying a theme, 
 use the [Spectrum](https://spectrum.chat/spicetify) chat. 
 
-- For bugs and requesting new features, [open an issue](https://github.com/morpheusthewhite/spicetify-themes/issues/new/choose) on GitHub
+- For bugs and requesting new features, [open an issue](https://github.com/morpheusthewhite/spicetify-themes/issues/new/choose) on GitHub.
 
 If you are unsure about which one to use, go for Spectrum.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,20 @@ You can add your own theme simply by opening a Pull Request (more info in the [C
 
 ## Installation and usage
 
-(If you use Arch Linux you can find this project on the [AUR](https://aur.archlinux.org/packages/spicetify-themes-git/)).
+(If you use Arch Linux you can find this project on the [AUR](https://aur.archlinux.org/packages/spicetify-themes-git/))
 
-### Clone this repository. Make sure [git](https://git-scm.com/) is installed and run:
+1. Clone this repository. Make sure [git](https://git-scm.com/) is installed and run:
 
 ```bash
 git clone https://github.com/morpheusthewhite/spicetify-themes.git
 ```
 
-### Copy the files into the [Spicetify Themes folder](https://github.com/khanhas/spicetify-cli/wiki/Customization#themes). Run:
+2. Copy the files into the [Spicetify Themes folder](https://github.com/khanhas/spicetify-cli/wiki/Customization#themes). Run:
 
-**Windows** 
-
-```powershell
+**Linux**
+```bash
 cd spicetify-themes
-cp * "$(spicetify -c | Split-Path)\Themes\"
+cp -r * ~/.config/spicetify/Themes
 ```
 
 **MacOS**
@@ -37,18 +36,18 @@ cd spicetify-themes
 cp -r * ~/spicetify_data/Themes
 ```
 
-**Linux**
-```bash
-cd spicetify-themes
-cp -r * ~/.config/spicetify/Themes
-```
+**Windows** 
 
+```powershell
+cd spicetify-themes
+cp * "$(spicetify -c | Split-Path)\Themes\"
+```
   
-### Choose which theme to apply just by running: 
+3. Choose which theme to apply just by running: 
 ```bash
 spicetify config current_theme THEME_NAME. 
 ```
-#### Some themes have 2 or more different color schemes. After selecting the theme you can switch between them with:
+Some themes have 2 or more different color schemes. After selecting the theme you can switch between them with:
 ```bash
 spicetify config color_scheme SCHEME_NAME
 ```


### PR DESCRIPTION
- Link to downloading old spicetify
- Link between sections of page
- Link to open an issue
- Moved important "notes" into one section at the top
- Reworked installation section to make it more clear
- Grammar and clarity (this is quite subjective, so feel free to reject this if the old wording makes more sense to you)

Ideally there would be a page for instructions on downloading old Spotify, something like
1. Uninstall Spotify
2. Download <v1.1.56
3. Download [spicetify v1.2.1](https://github.com/khanhas/spicetify-cli/wiki/Installation#legacy-spotif)
4. Stop updates by protecting folders

But for the moment I've just added a link to Spicetify's page on downloading the old Spicetify version 