### PR TITLE
fix(Dribblish): fix Windows install script

### DIFF
--- a/Dribbblish/install.ps1
+++ b/Dribbblish/install.ps1
@@ -7,10 +7,10 @@ if ($null -eq $checkSpice) {
 
 Write-Host "Downloading themes package:" -ForegroundColor Green
 $zipFile = "$env:TEMP\spicetify-themes.zip"
-Invoke-WebRequest "https://github.com/morpheusthewhite/spicetify-themes/archive/refs/heads/v2.zip" -OutFile $zipFile
+Invoke-WebRequest "https://github.com/morpheusthewhite/spicetify-themes/archive/refs/heads/master.zip" -OutFile $zipFile
 
 Write-Host "Extracting themes package:" -ForegroundColor Green
-$extractPath = "$env:TEMP\spicetify-themes-2"
+$extractPath = "$env:TEMP\spicetify-themes-master"
 if (Test-Path $extractPath) {
     Remove-Item $extractPath -Recurse -Force
 }


### PR DESCRIPTION
The Windows install script was trying to get the file from the `v2` branch and was trying to get into that path once extracted.
This has been fixed by changing calls for `v2` back to `master`.