### PR TITLE
fix(Sleek): fix for minor css mapping change

### DIFF
--- a/Sleek/user.css
+++ b/Sleek/user.css
@@ -153,7 +153,7 @@ ul.main-navBar-entryPoints > div.GlueDropTarget >*.active {
 }
 
 /* hide and move progress time location */
-.playback-bar__progress-time-elapsed.main-type-finale {
+.playback-bar__progress-time-elapsed {
   opacity: 0;
   position: absolute;
   bottom: 13px;
@@ -161,7 +161,7 @@ ul.main-navBar-entryPoints > div.GlueDropTarget >*.active {
   transition-duration: 0.15s;
 }
 
-.main-playbackBarRemainingTime-container {
+.z7ggpzN06UkYg7bLwVqT {
   opacity: 0;
   position: absolute;
   bottom: 13px;
@@ -170,8 +170,8 @@ ul.main-navBar-entryPoints > div.GlueDropTarget >*.active {
 }
 
 /* show time on hover */
-.playback-bar:hover .playback-bar__progress-time-elapsed.main-type-finale,
-.playback-bar:hover .main-playbackBarRemainingTime-container {
+.playback-bar:hover .playback-bar__progress-time-elapsed ,
+.playback-bar:hover .z7ggpzN06UkYg7bLwVqT {
   opacity: 1;
 }
 

--- a/Sleek/user.css
+++ b/Sleek/user.css
@@ -153,7 +153,7 @@ ul.main-navBar-entryPoints > div.GlueDropTarget >*.active {
 }
 
 /* hide and move progress time location */
-.playback-bar__progress-time {
+.playback-bar__progress-time-elapsed.main-type-finale {
   opacity: 0;
   position: absolute;
   bottom: 13px;
@@ -170,7 +170,7 @@ ul.main-navBar-entryPoints > div.GlueDropTarget >*.active {
 }
 
 /* show time on hover */
-.playback-bar:hover .playback-bar__progress-time,
+.playback-bar:hover .playback-bar__progress-time-elapsed.main-type-finale,
 .playback-bar:hover .main-playbackBarRemainingTime-container {
   opacity: 1;
 }


### PR DESCRIPTION
The CSS mapping for elapsed time changed so the elapsed time wasn't hidden anymore.

Tested on Spotify for Windows
1.1.70.610.g4585142b