### PR TITLE
fix(Dribbblish): make context menu readable

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -176,7 +176,7 @@ span.artist-artistVerifiedBadge-badge svg > path:last-of-type {
 .main-contextMenu-menuItemButton,
 .main-contextMenu-menuItemButton:not(.main-contextMenu-disabled):focus,
 .main-contextMenu-menuItemButton:not(.main-contextMenu-disabled):hover {
-    color: var(--spice-main);
+    color: var(--spice-text);
 }
 
 .main-playPauseButton-button {


### PR DESCRIPTION
https://github.com/morpheusthewhite/spicetify-themes/issues/600#issue-1046319608
I'm not too familiar with css so forgive me if there's something wrong with this, as far as I tested it it should work though.