### PR TITLE
docs(README): update README.md for Fluent theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can add your own theme simply by opening a Pull Request (more info in [CONTR
 ## Notes:
 
 *   **These themes require you to have the latest version of Spotify and Spicetify.**
-*   **To install Dribbblish and Turntable, follow the instructions in their READMEs**.
+*   **To install Dribbblish, Turntable and Fluent themes - follow the instructions in their READMEs**.
 *   **Spotify ad-blocked version is not supported.**
 
 ## Installation and usage


### PR DESCRIPTION
Update the notes section in README.md for Fluent theme installation. The theme requires installation commands given in it's [readme](https://github.com/morpheusthewhite/spicetify-themes/tree/master/Fluent#readme)