### PR TITLE
input-bar-modification

### DIFF
--- a/Sleek/user.css
+++ b/Sleek/user.css
@@ -262,12 +262,17 @@ p.main-buddyFeed-timestamp.main-type-finale,
   display: none;
 }
 
+ /* remove vector (circle) from input bar to allow padding to be reduced */
+ .jnJioQZqKVcbP_kkmTQ2 {
+   opacity: 0;
+ } 
+
 /* change input box appearance */
 input {
   background-color: unset !important;
   border-bottom: solid 1px var(--spice-text) !important;
   border-radius: 0 !important;
-  padding: 6px 10px 6px 48px;
+  padding: 6px 10px !important;
   color: var(--spice-text) !important;
 }
 


### PR DESCRIPTION
Modification of user.css in sleek. I think it looks nicer with the padding of the input box being reduced, (text is closer to the left of the input box now), [change on line 275]. However, there is a vector in the input box which has to be removed so that the letters typed by the user aren't covered by it, [change on lines 265-269].
![Sleek pull req](https://user-images.githubusercontent.com/62380385/145072945-6e57d60c-a1cc-4e67-8b15-81bce1a4f460.png)

Screenshot of results after changes.