### PR TITLE
[BurntSienna] Fixed CSS not applying to elapsed time

### DIFF
--- a/BurntSienna/user.css
+++ b/BurntSienna/user.css
@@ -37,7 +37,7 @@ h1 {
 
 /* Progress and remaining time */
 .main-playbackBarRemainingTime-container,
-.playback-bar__progress-time {
+.playback-bar__progress-time-elapsed {
 	font-size: 15px;
 	margin-left: 5px;
 	margin-right: 5px;

--- a/BurntSienna/user.css
+++ b/BurntSienna/user.css
@@ -37,7 +37,8 @@ h1 {
 
 /* Progress and remaining time */
 .main-playbackBarRemainingTime-container,
-.playback-bar__progress-time-elapsed {
+.playback-bar__progress-time-elapsed,
+.playback-bar__progress-time {
 	font-size: 15px;
 	margin-left: 5px;
 	margin-right: 5px;


### PR DESCRIPTION
In the BurntSienna theme, the elapsed time wouldn't apply the CSS that was applied to the remaining time. It's possible that Spotify changed the class name. This PR fixes this by adapting the class name in the user.css file.