### PR TITLE
Added Beach-Sunset in dribblish README list.

### DIFF
--- a/Dribbblish/README.md
+++ b/Dribbblish/README.md
@@ -80,7 +80,7 @@ xpui.js_repl_8008 = ,${1}56,
 ```
 
 ## Change Color Schemes
-There are 9 color schemes you can choose: `base`, `white`, `dark`, `dracula`, `nord-dark`, `nord-light`, `samourai`, `purple`. Change scheme with commands:
+There are 9 color schemes you can choose: `base`, `white`, `dark`, `dracula`, `nord-dark`, `nord-light`, `beach-sunset`, `samourai`, `purple`. Change scheme with commands:
 ```
 spicetify config color_scheme <scheme name>
 spicetify apply


### PR DESCRIPTION
In the README for the dribblish theme, at the very bottom it lists the 9 choices for the theme. It didn't include beach-sunset, so that has been corrected and added.