### PR TITLE
fix(Ziro): breaking changes for 1.1.87

### DIFF
--- a/Ziro/user.css
+++ b/Ziro/user.css
@@ -509,7 +509,7 @@ input:checked ~ .x-toggle-indicatorWrapper .x-toggle-indicator {
   border-radius: var(--br-1);
 }
 
-.McwcCfBLSuXa5UDU1IMw {
+.main-rootlist-rootlistDividerContainer {
   display: none;
 }
 


### PR DESCRIPTION
some changes i made for ziro theme with spicetify 2.10.1 and spotify 1.1.87

changelog:
- remove navbar playlist top gradient
- remove home-hover gradient
- fix tracklist card, bottom corner radius
- fix playback-bar progress-time placing

![Screen Shot 2022-06-09 at 22 37 18](https://user-images.githubusercontent.com/13508492/172888135-a7920319-ca49-42ff-8bb7-8a1b20eea07e.png)
