### PR TITLE
fix(Sharkblue): update the windows controls colours

### DIFF
--- a/SharkBlue/user.css
+++ b/SharkBlue/user.css
@@ -9,7 +9,11 @@
 }
 .Root__now-playing-bar,
 .Root__now-playing-bar footer {
-  border-radius: var(--border-radius-1) !important;
+  border-radius: 8px !important;
+}
+.Root__right-sidebar,
+.UrfDp0_mKGL9hkfh9g_R {
+  border-radius: 8px !important;
 }
 
 /* transparent window controls */
@@ -347,3 +351,7 @@ highlights selected song contains multi-digit song numbers */
   width: 24px;
   height: 24px;
 } */
+
+.playlist-playlist-actionBarBackground-background {
+  visibility: hidden;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Consolidated desktop window-control visuals into a single fixed top-right overlay with increased height and preserved high layering.
  * Added a subtle backdrop-brightness effect for improved contrast.
  * Set now-playing bar and right sidebar corners to a fixed 8px radius for consistent rounding.
  * Introduced a small 6px rounded-corner utility.
  * Hid the playlist action bar background and preserved an existing commented SVG snippet.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->