### PR TITLE
fix(Sleek): invisible text on input

### DIFF
--- a/Sleek/user.css
+++ b/Sleek/user.css
@@ -350,7 +350,6 @@ MAIN VIEW
 
 /* change input box appearance */
 input {
-  background-color: var(--spice-main-secondary) !important;
   border-radius: 8px !important;
   padding: 6px 10px 6px 48px;
   color: var(--spice-text) !important;


### PR DESCRIPTION
Removed the background color override for input boxes, fixes issue https://github.com/spicetify/spicetify-themes/issues/1169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated input field styling. Input elements now display with default background appearance instead of custom coloring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->