### PR TITLE
centering play icon in left sidebar

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -937,3 +937,9 @@ img.playlist-picture[src$=".svg"] {
 .Root__main-view-overlay {
     width: 100%;
 }
+.Button-buttonTertiary-textBase-medium-iconOnly-useBrowserDefaultFocusStyle {
+  min-block-size: 40px;
+  height: 40px;
+  width: 40px;
+}
+


### PR DESCRIPTION
before:
<img width="226" height="74" alt="image" src="https://github.com/user-attachments/assets/46c01d3e-e119-4be8-ac2f-4ac0caf09396" />

after:
<img width="215" height="73" alt="image" src="https://github.com/user-attachments/assets/ad6a18d0-08a4-484c-a89a-29b723c2d955" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button sizing for improved visual consistency across the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->