### PR TITLE
fix(Dribbblish): centering play icon in left sidebar

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -937,3 +937,10 @@ img.playlist-picture[src$=".svg"] {
 .Root__main-view-overlay {
     width: 100%;
 }
+
+
+.Button-buttonTertiary-textBase-medium-iconOnly-useBrowserDefaultFocusStyle {
+  min-block-size: 40px;
+  height: 40px;
+  width: 40px;
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted button component sizing to ensure consistent display dimensions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

before:
<img width="226" height="74" alt="image" src="https://github.com/user-attachments/assets/643b306e-b271-4d73-82d5-4b94cfc4ac58" />

after:
<img width="215" height="73" alt="image" src="https://github.com/user-attachments/assets/a0e695fa-924d-4386-917c-1f085008e952" />
