### PR TITLE
fix(dribbblish): centering playlist icons

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -944,3 +944,8 @@ img.playlist-picture[src$=".svg"] {
   height: 40px;
   width: 40px;
 }
+
+
+.HeaderSideArea {
+    padding-left: 4px;
+}


### PR DESCRIPTION
before:
<img width="75" height="335" alt="image" src="https://github.com/user-attachments/assets/486a8376-cd02-4863-9d6e-48a674da9945" />
after:
<img width="77" height="318" alt="image" src="https://github.com/user-attachments/assets/ec9db95e-5163-4eca-8d09-2b050dcfa35d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced header side area styling with improved spacing adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->