### PR TITLE
fix(Dribbblish): fix back shadow layout

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -539,7 +539,7 @@ li>div::after {
 /* add main backshadow */
 #dribbblish-back-shadow {
     z-index: 5;
-    grid-area: main-view / main-view / now-playing-bar / main-view;
+    grid-area: 1 / 2 / 5 / 5;
     box-shadow: 0 0 10px 3px #0000003b;
     border-radius: var(--corner-radius);
     pointer-events: none;
@@ -949,3 +949,4 @@ img.playlist-picture[src$=".svg"] {
 .HeaderSideArea {
     padding-left: 4px;
 }
+


### PR DESCRIPTION
before:
<img width="1571" height="768" alt="image" src="https://github.com/user-attachments/assets/283adb45-db3c-45b8-81f2-859f288e8933" />
<img width="197" height="123" alt="image" src="https://github.com/user-attachments/assets/e4c7aef7-3f16-46fd-98a1-3b60c52d0bc9" />

after:
<img width="1572" height="769" alt="image" src="https://github.com/user-attachments/assets/ac999453-bd63-4ab7-ba9e-20757b3b7686" />
<img width="139" height="98" alt="image" src="https://github.com/user-attachments/assets/7deb2389-c969-4c58-93fa-351ed6f60289" />

The shadow has been adjusted to the correct position and size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the positioning of a shadow element within the interface to improve visual alignment and layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->