### PR TITLE
fix(text): add podcast control text labels

### DIFF
--- a/text/user.css
+++ b/text/user.css
@@ -881,12 +881,9 @@ button
     content: "\21C4\2726";
     text-wrap: nowrap;
 }
-button[data-testid="control-button-seek-back-15"] > span::before,
-button
-    > span:has(
-        path[d="M2.464 4.5h1.473a.75.75 0 0 1 0 1.5H0V2.063a.75.75 0 0 1 1.5 0v1.27a8.25 8.25 0 1 1 10.539 12.554.75.75 0 0 1-.828-1.25A6.75 6.75 0 1 0 2.464 4.5Z"]
-    )::after {
-    content: "\21A9";
+button[data-testid="control-button-seek-back-15"] > span:first-child::after {
+    content: "-15s";
+    white-space: nowrap;
 }
 .main-skipBackButton-button::before,
 button[data-testid="control-button-skip-back"] > span::after {
@@ -956,20 +953,36 @@ button[data-testid="control-button-repeat"][aria-checked="mixed"]
     content: "\21BB\2474";
     text-wrap: nowrap;
 }
-button[data-testid="control-button-seek-forward-15"] > span::before,
-button:has(
-        path[d="M13.536 4.488h-1.473a.75.75 0 1 0 0 1.5H16V2.051a.75.75 0 0 0-1.5 0v1.27A8.25 8.25 0 1 0 3.962 15.876a.75.75 0 0 0 .826-1.252 6.75 6.75 0 1 1 8.747-10.136Z"]
-    )
-    > span::after {
-    content: "\21AA";
+button[data-testid="control-button-seek-forward-15"] > span:first-child::after {
+    content: "+15s";
+    white-space: nowrap;
 }
+/* podcast controls */
+button[data-testid="control-button-playback-speed"] > span.hidden-visually {
+    width: auto !important;
+    height: auto !important;
+    clip: auto !important;
+    white-space: nowrap;
+}
+button[data-testid="control-button-sleep-timer"] > span:first-child::after {
+    content: "\29D6";
+    font-size: 10px;
+}
+button[data-testid="control-button-npv-episodes"] > span::after {
+    content: "list";
+    font-size: 10px;
+}
+
 .main-shuffleButton-button > svg,
 .main-skipBackButton-button > svg,
 .main-playPauseButton-button > svg,
 .main-skipForwardButton-button > svg,
 .main-repeatButton-button > svg,
-:is(.player-controls__buttons, .npv-nowPlayingBar-controls) svg {
-    display: none;
+:is(.player-controls__buttons, .npv-nowPlayingBar-controls) svg,
+button[data-testid="control-button-playback-speed"] svg,
+button[data-testid="control-button-sleep-timer"] svg,
+button[data-testid="control-button-npv-episodes"] svg {
+    display: none !important;
 }
 
 /* connect bar */


### PR DESCRIPTION
Replace Unicode emoji icons with plain text labels for podcast controls to prevent UI issues. Controls affected: playback speed, sleep timer, episodes, and 15s skip buttons.

after the pr

<img width="430" height="112" alt="image" src="https://github.com/user-attachments/assets/6437f213-ad56-41d6-9f48-c7a06b32f033" />

before the pr

<img width="430" height="112" alt="image" src="https://github.com/user-attachments/assets/3d16c0d0-c7b3-45dd-bda2-91b0bc69f5eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated podcast player control appearance and labeling for better usability and accessibility.
  * Seek buttons now show clear "-15s" and "+15s" text labels instead of icon-only glyphs.
  * Playback speed, sleep timer and episodes controls receive descriptive text labels and consistent sizing behavior.
  * Underlying decorative SVGs for these controls are hidden to prioritize the new textual labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->