### PR TITLE
fix(text): restore progress and volume bar styles for latest Spotify UI

### DIFF
--- a/text/user.css
+++ b/text/user.css
@@ -304,7 +304,8 @@ img[src*="equaliser"] {
     background-color: transparent !important;
     background-image: none;
 }
-.progress-bar {
+.progress-bar,
+[data-testid="progress-bar"] {
     --fg-color: var(--spice-button-active);
     --bg-color: var(--spice-button-disabled);
 }
@@ -792,24 +793,30 @@ form .main-topBar-searchBar:placeholder-shown {
 }
 
 /* playback seek bar */
-.playback-progressbar-container {
-    position: absolute;
-    width: 100%;
+.main-nowPlayingBar-container .playback-bar {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: center !important;
 }
-.progress-bar,
-.playback-progressbar-container div[data-testid="progress-bar"] {
-    --progress-bar-height: 16px;
+.main-nowPlayingBar-container .playback-bar > div:has(> [data-testid="playback-progressbar"]) {
+    position: absolute !important;
+    width: 100% !important;
+    height: 16px !important;
+    left: 0 !important;
+    top: 50% !important;
+    transform: translateY(-50%) !important;
+}
+.main-nowPlayingBar-container .playback-bar [data-testid="progress-bar"] {
+    --progress-bar-height: 16px !important;
     --progress-bar-radius: calc(var(--border-radius) / 2) !important;
 }
-.progress-bar__slider,
-.playback-progressbar-container
-    div[data-testid="progress-bar"]
-    div[data-testid="progressbar-bar-background"]
-    div[data-testid="progress-bar-handle"] {
-    box-shadow: none;
-    height: 100%;
-    border-radius: 0;
-    background-color: var(--spice-text);
+.main-nowPlayingBar-container .playback-bar .progress-bar__slider,
+.main-nowPlayingBar-container .playback-bar [data-testid="progress-bar-handle"] {
+    box-shadow: none !important;
+    height: 100% !important;
+    border-radius: 0 !important;
+    background-color: var(--spice-text) !important;
 }
 .x-progressBar-fillColor {
     transition-duration: unset;
@@ -830,19 +837,24 @@ form .main-topBar-searchBar:placeholder-shown {
 }
 
 /* volume bar */
-.volume-bar .progress-bar {
-    --progress-bar-height: calc(var(--font-size) / 6);
+.main-nowPlayingBar-container .main-nowPlayingBar-right [data-testid="progress-bar"] {
+    --progress-bar-height: calc(var(--font-size) / 6) !important;
 }
-.volume-bar .progress-bar__slider {
-    height: 16px;
+.main-nowPlayingBar-container .main-nowPlayingBar-right .progress-bar__slider,
+.main-nowPlayingBar-container .main-nowPlayingBar-right [data-testid="progress-bar-handle"] {
+    height: 16px !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    background-color: var(--spice-text) !important;
 }
-.volume-bar .x-progressBar-progressBarBg {
-    background-color: transparent;
-    border-bottom: var(--progress-bar-height) dashed rgba(var(--spice-rgb-subtext), 0.3);
+.main-nowPlayingBar-container .main-nowPlayingBar-right .x-progressBar-progressBarBg,
+.main-nowPlayingBar-container .main-nowPlayingBar-right [data-testid="progress-bar-background"] {
+    background-color: transparent !important;
+    border-bottom: var(--progress-bar-height) dashed rgba(var(--spice-rgb-subtext), 0.3) !important;
 }
-.volume-bar .x-progressBar-fillColor {
+.main-nowPlayingBar-container .main-nowPlayingBar-right .x-progressBar-fillColor {
     background-color: var(--spice-main) !important;
-    border-bottom: var(--progress-bar-height) dashed var(--fg-color);
+    border-bottom: var(--progress-bar-height) dashed var(--fg-color) !important;
 }
 
 /* player controls */
@@ -914,9 +926,6 @@ button[data-testid="control-button-playpause"]
     content: "\25B6";
 }
 .main-playPauseButton-button[aria-label="Pause"]::before,
-.main-playPauseButton-button:has(
-        path[d="M3 1.713a.7.7 0 0 1 1.05-.607l10.89 6.288a.7.7 0 0 1 0 1.212L4.05 14.894A.7.7 0 0 1 3 14.288V1.713z"]
-    )::after,
 button[data-testid="control-button-playpause"]
     > span
     > span:has(


### PR DESCRIPTION
fixed #1272 
- Resolved layout breakage in the playback progress bar caused by Spotify's shift to a CSS grid structure. Forced a flex layout and applied absolute positioning to correctly overlay elapsed/remaining time indicators over the full-width progress bar.
- Updated obsolete `.progress-bar` selectors to target the new `.kPLEzaZADEAjWLC2` hashed class and `data-testid="progress-bar"` attributes.
- Isolated structural playback bar overrides (16px thickness, flex layout) exclusively to `.playback-bar` to prevent them from unintentionally hijacking the volume bar layout.
- Restored original volume bar dashed styling and background masking. Replaced the deprecated `.volume-bar` container class with `.main-nowPlayingBar-right` and swapped out the removed `--font-size` CSS variable with a fixed 2px fallback.


Before :

<img width="1906" height="123" alt="image" src="https://github.com/user-attachments/assets/000962ac-cb9b-4546-a93d-9492232e0fae" />

After :

<img width="1906" height="123" alt="image" src="https://github.com/user-attachments/assets/edcbeca0-5f7d-4a67-86e7-a1043ed61a58" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggles to show/hide cover art and sidebar images; improved fullscreen now-playing scaling and transform behavior.

* **Bug Fixes**
  * Fixed layout overflow, header transparency, and background/color consistency across navigation and panes.
  * Aligned playback bar positioning and progress visuals; constrained right-side controls for a thinner progress representation.

* **Style**
  * Updated typography, pane header labels, selection/hover states, progress recoloring, control glyphs, and connect bar text color.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spicetify/spicetify-themes/pull/1277)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->