### PR TITLE
fix(Dribbblish): restore artist header layout

### DIFF
--- a/Dribbblish/user.css
+++ b/Dribbblish/user.css
@@ -481,11 +481,12 @@ li>div::after {
     -webkit-mask-repeat: no-repeat;
 }
 
-/* full screen artists background */
+/* artist page background */
 .main-entityHeader-container.main-entityHeader-withBackgroundImage,
 .main-entityHeader-background,
 .main-entityHeader-background.main-entityHeader-overlay:after {
-    height: 100vh;
+    height: 40vh;
+    max-height: none;
 }
 
 .artist-artistOverview-overview .main-entityHeader-withBackgroundImage h1 {
@@ -500,7 +501,7 @@ li>div::after {
 }
 
 .artist-artistOverview-overview .main-entityHeader-headerText {
-    justify-content: center;
+    justify-content: flex-end;
 }
 
 /* progress bar moves smoothly */


### PR DESCRIPTION
## Summary
- Restore Dribbblish artist pages to Spotify current 40vh header behavior
- Align artist header text to the bottom of the banner again
- Keep the artist controls and Popular section visible without the extra initial scroll

## Verification
- Tested locally on Spotify 1.2.90.451 with Spicetify 2.43.2
- Confirmed the artist header no longer computes to a full viewport height
- Ran `git -c core.whitespace=cr-at-eol diff --check`

Related: #1132
Related: #1269, which appears to show a similar artist-page layout regression in Blackout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced artist page background height from full-screen coverage to a more compact viewport-relative size, creating better visual balance.
  * Modified artist header text alignment from centered to right-aligned positioning for improved layout aesthetics.
  * Adjusted layout constraints to allow more flexible background sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->