### PR TITLE
fix(StarryNight): sync cover art spin state

### DIFF
--- a/StarryNight/theme.js
+++ b/StarryNight/theme.js
@@ -74,35 +74,6 @@ waitForElement(['.Root__top-container'], ([topContainer]) => {
 
     resizeObserver.observe(rightbar);
   });
-  
-  waitForElement(['[data-encore-id="buttonPrimary"]'], ([targetElement]) => {
-    // start or stop spinning animation based on whether something is playing
-    const playObserver = new MutationObserver((mutationsList) => {
-      for (const mutation of mutationsList) {
-        if (
-          mutation.type === 'attributes' &&
-          mutation.attributeName === 'aria-label'
-        ) {
-          handleLabelChange();
-        }
-      }
-    });
-  
-    const playConfig = { attributes: true, attributeFilter: ['aria-label'] };
-    playObserver.observe(targetElement, playConfig);
-  });
-
-  function handleLabelChange() {
-    const img = document.querySelector(
-      '.main-nowPlayingWidget-coverArt .cover-art img'
-    );
-    // checks the state of the play button on the playbar
-    if (document.querySelector('[data-encore-id="buttonPrimary"]').getAttribute('aria-label') == 'Pause'){
-      img.classList.add('running-animation');
-    } else {
-      img.classList.remove('running-animation');
-    }
-  }
 
   /*
   Pure CSS Shooting Star Animation Effect Copyright (c) 2021 by Delroy Prithvi (https://codepen.io/delroyprithvi/pen/LYyJROR)

--- a/StarryNight/user.css
+++ b/StarryNight/user.css
@@ -209,7 +209,12 @@
   box-shadow: 0 0 5px 5px var(--spice-text);
 }
 
-.running-animation {
+[data-testid="now-playing-bar"]:has(
+  [data-testid="control-button-playpause"][aria-label="Pause"]
+)
+  .main-nowPlayingWidget-coverArt
+  .cover-art
+  img {
   animation-play-state: running !important;
 }
 


### PR DESCRIPTION
This fixes the StarryNight cover art rotation state.

Previously, the cover art animation state was only updated after the play/pause
button's aria-label changed. As a result, the cover art did not start spinning
until the user toggled play/pause once.

Changes:
- Sync the animation state immediately after attaching the play button observer.
- Re-apply the animation state when the cover art is re-rendered.
- Guard against missing play button or cover image elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved play/pause handling so the animated cover reacts more reliably to the current player state.
  * Updated the animation logic to use a more precise condition based on the Now Playing bar’s play/pause control having an exact **“Pause”** label.
  * Removed redundant label-change observation logic related to cover animation toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->